### PR TITLE
Add compatibility with public managed db and improve chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 bin
 testbin/*
 Dockerfile.cross
+public-cloud-databases-operator
 
 # Test binary, build with `go test -c`
 *.test
@@ -24,3 +25,4 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -1,22 +1,52 @@
 # public-cloud-databases-operator
- 
+
 This operator allow you to automaticaly authorize your Kubernetes cluster IP on your OVHcloud cloud databases service.
 
+## Requirement
+
+### Public or private network
+
+This operator is compatible with public and private managed database.
+
+#### Managed database in private mode
+
+If the managed database is deployed in `private` mode, `private` IP addresses of the Kubernetes nodes will be trusted.
+The Kubernetes cluster must be deployed in the same network used by managed database.
+
+#### Managed database in public mode and Kubernetes cluster `without`` GW
+
+If the managed database is deployed in `public` mode, `public` IP addresses of the Kubernetes nodes will be trusted.
+
+#### Managed database in public mode and Kubernetes cluster `with`` GW
+
+The OVHcloud managed Kubernetes cluster can be configured to use a GW to reach internet.
+If the managed database is deployed in `public` mode and a GW was configured on the managed Kubernetes, the `public` IP address of the GW will be trusted.
+
+To determine the public IP address of the GW used by the Kubernetes cluster, the operator will request `https://ifconfig.io` and use the returned IP.
+
+In this case, the operator must be deployed in the kubernetes cluster consuming targeted managed database.
+If deployed outside the Kubernetes cluster, the returned IP address will be the public IP of the default GW of the machine running the operator. That can be different than the default GW used by Kubernetes nodes.
+
 ## Ovh Credentials
-The operator needs a secret that contains the credentials to call Ovhcloud api. Go to https://api.ovh.com/createToken/ to generate the credentials namely:
+
+The operator needs a secret that contains the credentials to call Ovhcloud api. Go to <https://api.ovh.com/createToken/> to generate the credentials namely:
+
 - application key
 - application secret
 - consumer key
 
 Define the credentials ACL in order to be able to make these requests:
+
 - GET /cloud/project/:projectID/database/service
 - GET /cloud/project/:projectID/database/service/:serviceId
 - PUT /cloud/project/:projectID/database/:engine/:serviceId
 
 ## Values
-Create a values.yaml to be injected in the helm chart 
+
+Create a values.yaml to be injected in the helm chart
 that will be created afterwards. Region is either: ovh-eu, ovh-ca or ovh-us.
 You can find the file in /examples.
+
 ```yaml
 ovhCredentials:
   applicationKey: XXXX
@@ -28,12 +58,15 @@ namespace: XXXX #Your Kubernetes namespace
 ```
 
 ## Installation
+
 Use the kubernetes package manager [helm](https://helm.sh) and the values file you created to install the operator.
 
 ```bash
 helm install -f values.yaml public-cloud-databases-operator oci://registry-1.docker.io/ovhcom/public-cloud-databases-operator --version 3
 ```
+
 That will create the operator, crd and secrets.
+
  ```bash
 kubectl get deploy
 NAME                                       READY   UP-TO-DATE   AVAILABLE   AGE
@@ -49,8 +82,10 @@ ovh-credentials   Opaque   4      12m
 ```
 
 ## Create Custom Resource
+
 Create a custom resource object using this example file.
 You can find the file in /examples.
+
 ```yaml
 apiVersion: cloud.ovh.net/v1alpha1
 kind: Database
@@ -71,29 +106,30 @@ The field serviceId is optional. If not set, the operator will be run against al
 kubectl apply -f cr.yaml
 ```
 
-# Nodes Labels
-You can use kubernetes labeling in order to select specific nodes that you want the operator to be run against. 
+## Nodes Labels
+
+You can use kubernetes labeling in order to select specific nodes that you want the operator to be run against.
 The created CR and the node must have the same label and value.
 
 ```bash
 kubectl label nodes NODENAME1 NODENAME2 ... LABELNAME=LABELVALUE
 ```
 
-# Related links
- 
- * Contribute: https://github.com/ovh/public-cloud-databases-operator/blob/master/CONTRIBUTING.md
- * Report bugs: https://github.com/ovh/public-cloud-databases-operator/issues
+## Related links
 
-# License
- 
+- Contribute: <https://github.com/ovh/public-cloud-databases-operator/blob/master/CONTRIBUTING.md>
+- Report bugs: <https://github.com/ovh/public-cloud-databases-operator/issues>
+
+## License
+
 Copyright 2021 OVH SAS
- 
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
- 
+
     http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This operator is compatible with public and private managed database.
 If the managed database is deployed in `private` mode, `private` IP addresses of the Kubernetes nodes will be trusted.
 The Kubernetes cluster must be deployed in the same network used by managed database.
 
-#### Managed database in public mode and Kubernetes cluster `without`` GW
+#### Managed database in public mode and Kubernetes cluster `without` GW
 
 If the managed database is deployed in `public` mode, `public` IP addresses of the Kubernetes nodes will be trusted.
 
-#### Managed database in public mode and Kubernetes cluster `with`` GW
+#### Managed database in public mode and Kubernetes cluster `with` GW
 
 The OVHcloud managed Kubernetes cluster can be configured to use a GW to reach internet.
 If the managed database is deployed in `public` mode and a GW was configured on the managed Kubernetes, the `public` IP address of the GW will be trusted.

--- a/controllers/ovh_api.go
+++ b/controllers/ovh_api.go
@@ -10,8 +10,10 @@ type IpRestriction struct {
 	Description string `json:"description"`
 }
 type Cluster struct {
-	Engine string          `json:"engine"`
-	Ips    []IpRestriction `json:"ipRestrictions"`
+	ID          string          `json:"id"`
+	Engine      string          `json:"engine"`
+	Ips         []IpRestriction `json:"ipRestrictions"`
+	NetworkType string          `json:"networkType"`
 }
 type ClusterUpdate struct {
 	Ips []IpRestriction `json:"ipRestrictions"`

--- a/deploy/public-cloud-databases-operator/templates/_helpers.tpl
+++ b/deploy/public-cloud-databases-operator/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "public-cloud-databases-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name for the credentials secret.
+*/}}
+{{- define "ovhcreds.secretName" -}}
+{{- if .Values.ovhCredentials.existingSecret -}}
+  {{- .Values.ovhCredentials.existingSecret -}}
+{{- else -}}
+  {{ default (include "public-cloud-databases-operator.fullname" .) .Values.ovhCredentials.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/public-cloud-databases-operator/templates/deployment.yaml
+++ b/deploy/public-cloud-databases-operator/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "public-cloud-databases-operator.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "public-cloud-databases-operator.name" . }}
     chart: {{ include "public-cloud-databases-operator.chart" . }}
@@ -49,22 +49,22 @@ spec:
             - name: REGION
               valueFrom:
                 secretKeyRef:
-                  name: ovh-credentials
+                  name: {{ include "ovhcreds.secretName" $ }}
                   key: region
             - name: APPLICATION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ovh-credentials
+                  name: {{ include "ovhcreds.secretName" $ }}
                   key: applicationKey
             - name: APPLICATION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: ovh-credentials
+                  name: {{ include "ovhcreds.secretName" $ }}
                   key: applicationSecret
             - name: CONSUMER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ovh-credentials
+                  name: {{ include "ovhcreds.secretName" $ }}
                   key: consumerKey
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/public-cloud-databases-operator/templates/rbac.yaml
+++ b/deploy/public-cloud-databases-operator/templates/rbac.yaml
@@ -1,56 +1,43 @@
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "public-cloud-databases-operator.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 
 ---
-
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "public-cloud-databases-operator.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "public-cloud-databases-operator.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: {{ include "public-cloud-databases-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "public-cloud-databases-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: {{ include "public-cloud-databases-operator.fullname" . }}
-  namespace: {{ .Values.namespace }}
 rules:
   - apiGroups:
       - ""
     resources:
       - events
-      - pods
       - nodes
     verbs:
-      - '*'
-
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - '*'
+      - "*"
 
   - apiGroups:
       - cloud.ovh.net
     resources:
       - databases
     verbs:
-      - '*'
+      - "*"
 
   - apiGroups:
       - cloud.ovh.net

--- a/deploy/public-cloud-databases-operator/templates/secret.yaml
+++ b/deploy/public-cloud-databases-operator/templates/secret.yaml
@@ -1,12 +1,13 @@
+{{- if not .Values.ovhCredentials.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ovh-credentials
-  namespace:  {{ .Values.namespace }}
-
+  name: {{ include "ovhcreds.secretName" . }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  region: {{ .Values.ovhCredentials.region | b64enc  }}
-  applicationKey: {{  .Values.ovhCredentials.applicationKey | b64enc  }}
-  applicationSecret: {{ .Values.ovhCredentials.applicationSecret | b64enc  }}
-  consumerKey: {{  .Values.ovhCredentials.consumerKey | b64enc  }}
+  region: {{ .Values.ovhCredentials.region | b64enc }}
+  applicationKey: {{ .Values.ovhCredentials.applicationKey | b64enc }}
+  applicationSecret: {{ .Values.ovhCredentials.applicationSecret | b64enc }}
+  consumerKey: {{ .Values.ovhCredentials.consumerKey | b64enc }}
+{{- end -}}

--- a/deploy/public-cloud-databases-operator/values.yaml
+++ b/deploy/public-cloud-databases-operator/values.yaml
@@ -17,23 +17,28 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-imagePullSecrets:
-  - name: registry
+imagePullSecrets: []
 
 ovhCredentials:
+  ## Name of the secret to create if `useSecret` is true and `existingSecret` is empty. Optional.
+  ##
+  name:
+  ## Name of a pre-existing secret (if any) in the Operator namespace
+  ## that should be used to get API credentials. Optional.
+  ##
+  existingSecret:
+
+  ## This will automatically create the secret with you OVHcloud API creds
+  ##
   applicationKey: ""
   applicationSecret: ""
   consumerKey: ""
-  region: ""
-
+  region: "ovh-eu"
 
 resources: {}
-
-namespace: public-cloud-databases-operator
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
-


### PR DESCRIPTION
Hey,

I add a logic to detect if the MDB is deployed in public or private mode and based on that the operator is able to select public or private ip of node. If the Kubernetes cluster is configured to use a GW as egress instead using public ip of each node, the operator detect the public ip address used by this GW with `https://ifconfig.io`.

I also made some change on the chart:
- use helm release ns instead of ns specified in values (helm install ovh-db-operator -n ovh-db-operator --create-namespace .)
- remove unnecessary roles
- add ability to use an existing secret