### PR TITLE
Fix: Remove helm chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ namespace: XXXX #Your Kubernetes namespace
 Use the kubernetes package manager [helm](https://helm.sh) and the values file you created to install the operator.
 
 ```bash
-helm install -f values.yaml public-cloud-databases-operator oci://registry-1.docker.io/ovhcom/public-cloud-databases-operator --version 3
+helm install -f values.yaml public-cloud-databases-operator oci://registry-1.docker.io/ovhcom/public-cloud-databases-operator
 ```
 
 That will create the operator, crd and secrets.


### PR DESCRIPTION
In the README file it seems that the helm chart version is not good.
We can replace by 0.1.5 and simply remove the flag version to pull and install the latest version.