### PR TITLE
fix #21 : naming convention for version in docker image was wrong

### DIFF
--- a/deploy/public-cloud-databases-operator/Chart.yaml
+++ b/deploy/public-cloud-databases-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.6"
+appVersion: "v1.0.6"
 description: OVHcloud databases operator
 name: public-cloud-databases-operator
 version: 0.1.7


### PR DESCRIPTION
This PR fixes #21 by:
- changing appVersion from X.X.X to vX.X.X
- 
Signed-off-by: Cyril TAILLEFERT <cyril.taillefert@absyss.com>